### PR TITLE
Updated to 0.0.8-development in package.json

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -1,8 +1,8 @@
 {
   "name": "graphgen",
-  "version": "0.0.7-development",
+  "version": "0.0.8-development",
   "description": "Subgraph Generation Tool",
-  "license": "MIT",
+  "license": "Apache 2.0",
   "esy": {
     "build": "dune build -p graphgen",
     "buildDev":

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "graphgen",
-  "version": "0.1.0",
+  "version": "0.0.8-development",
   "description": "Subgraph Generation Tool",
-  "license": "MIT",
+  "license": "Apache 2.0",
   "esy": {
     "build": "dune build -p graphgen",
     "buildDev": "refmterr dune build --promote-install-files --root . --only-package #{self.name}",
     "release": {
       "rewritePrefix": true,
-      "releasedBinaries": [ "graphgen.exe" ]
+      "releasedBinaries": [
+        "graphgen.exe"
+      ]
     }
   },
   "scripts": {
@@ -22,5 +24,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "semantic-release": "^17.4.4"
+  },
+  "release": {
+    "branches": ["main", "next"]
   }
 }


### PR DESCRIPTION
- Manual version bump in config files (esy.json & package.json)
    - Automated version bumps will be added in a further PR
- Added missing config that prevented semantic-releases to generate the draft releases (we use the new main branch instead of master, which is the usual default release branch)