### PR TITLE
Add output-dir cmdline argument

### DIFF
--- a/lib/generator.re
+++ b/lib/generator.re
@@ -41,10 +41,10 @@ let dump_models = (models) =>
   List.map(((_, o)) => Jg_types.show_tvalue(o), models)
   |> String.concat("\n");
 
-let generate_directories = () => {
+let generate_directories = (output_dir) => {
   [
-    "subgraph/abis",
-    "subgraph/src/mappings"
+    [%string "%{output_dir}/abis"],
+    [%string"%{output_dir}/src/mappings"]
   ]
   |> List.fold_left((res, path) => Result.bind(res, _ => Dir.create(~path=true, Fpath.v(path))), Result.ok(true))
   |> Result.map_error((`Msg(msg)) => {

--- a/lib/generator.rei
+++ b/lib/generator.rei
@@ -1,5 +1,5 @@
-/** [generate_directories()] generates the subgraph directory structure and returns nothing. */
-let generate_directories: unit => result(bool, [> `Msg(string)]);
+/** [generate_directories(output_dir)] generates the subgraph directory structure at location [output_dir] and returns nothing. */
+let generate_directories: string => result(bool, [> `Msg(string)]);
 
 /** Type of Jingoo (Jinja2) models. */
 type models = list((string, Jingoo.Jg_types.tvalue));


### PR DESCRIPTION
Closes #50

GraphGen:
-Add new cmd line argument `-o OUTPUT_DIR, --output=OUTPUT_DIR` to set
the output directory of the subgraph

Generator:
-Add `output_dir` argument to `generate_directories` function