### PR TITLE
Fix automated release, changelog & versioning workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION 📣'
 tag-template: 'v$RESOLVED_VERSION'
 template: |
   ## Changes
@@ -14,7 +14,16 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
+    labels: 
+      - 'chore'
+      - 'devops'
+
+  - title: '📖 Documentation'
+    'label': 'documentation'
+
+  - title: '🧺 Miscellaneous' #Everything except ABAP
+    label: 'misc'
+
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.RELEASE_DIR }}
-          key: ${{ runner.OS }}-release-cache-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.OS }}-release-cache-${{ hashFiles('esy.lock/index.json'') }}
 
 
   Publish-npm:
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/work/graphgen/graphgen/_release/
-          key: ${{ runner.OS }}-release-cache-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.OS }}-release-cache-${{ hashFiles('esy.lock/index.json'') }}
            
       - run: cd /home/runner/work/graphgen/graphgen/_release/
       
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/work/graphgen/graphgen/_release/
-          key: ${{ runner.OS }}-release-cache-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.OS }}-release-cache-${{ hashFiles('esy.lock/index.json'') }}
           
       - run: cd /home/runner/work/graphgen/graphgen/_release/
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.7.0
           
       - name: Install esy
         run: npm install -g esy
@@ -33,9 +33,8 @@ jobs:
             cp -r templates/ _release/bin/ 
             
             cd _release/
-            cp package.json package_old.json
-            jq '.name |= "@protean-labs/graphgen"' package_old.json  | tee package.json
-            rm package_old.json
+            npm pkg set name=@protean-labs/graphgen
+            npm version ${{ github.ref }}
             
       - name: Cache release
         uses: actions/cache@v2
@@ -51,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.7.0
       
       - name: Retrieve release cache
         uses: actions/cache@v2
@@ -75,7 +74,7 @@ jobs:
       # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.7.0
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           # scope: '@protean-labs'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "graphgen": "esy x graphgen",
     "test": "esy x test.exe",
-    "overrideChangelog": "gren changelog --override",
+    "overrideChangelog": "gren changelog --override"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "esy": {
     "build": "dune build -p graphgen",
     "buildDev": "refmterr dune build --promote-install-files --root . --only-package #{self.name}",
-    "overrideChangelog": "gren changelog --override",
     "release": {
       "rewritePrefix": true,
       "releasedBinaries": [
@@ -17,7 +16,7 @@
   "scripts": {
     "graphgen": "esy x graphgen",
     "test": "esy x test.exe",
-    "semantic-release": "semantic-release"
+    "overrideChangelog": "gren changelog --override",
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fixes  #76
- Adds new changelog/release change types based on PR labels (devops, documentation, misc)
- Simplifies package.json manipulation during release using the updated npm v7.20.0
- Fix #37 , When a release is published on github, package.json version is automatically updated and a new version is published on npm