### PR TITLE
Bump graph-cli version

### DIFF
--- a/templates/manifest.j2
+++ b/templates/manifest.j2
@@ -13,7 +13,7 @@ dataSources:{% for dataSource in subgraph.dataSources %}{% set dataSource = data
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.3
+      apiVersion: 0.0.5
       language: wasm/assemblyscript
       file: ./src/mappings/{{ dataSource.contract.name }}.ts
       entities:
@@ -50,7 +50,7 @@ templates:{% for template in subgraph.templates %}
       abi: {{ template.contract.name }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.3
+      apiVersion: 0.0.5
       language: wasm/assemblyscript
       file: ./src/mappings/{{ template.contract.name }}.ts
       entities:

--- a/templates/package_json.j2
+++ b/templates/package_json.j2
@@ -7,14 +7,15 @@
     "codegen": "graph codegen --output-dir src/types/",
     "create-local": "graph create {{ subgraph.github_user }}/{{ subgraph.name }} --node http://127.0.0.1:8020",
     "build": "graph build",
+    "test": "graph test",
     "deploy-local": "graph deploy {{ subgraph.github_user }}/{{ subgraph.name }} --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
     "deploy": "graph deploy {{ subgraph.github_user }}/{{ subgraph.name }} --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy-staging": "graph deploy {{ subgraph.github_user }}/{{ subgraph.name }} --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/",
     "watch-local": "graph deploy {{ subgraph.github_user }}/{{ subgraph.name }} --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.16.0",
-    "@graphprotocol/graph-ts": "^0.16.0",
+    "@graphprotocol/graph-cli": "^0.22.0",
+    "@graphprotocol/graph-ts": "^0.22.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.2",

--- a/templates/util_ts.j2
+++ b/templates/util_ts.j2
@@ -2,8 +2,7 @@ import {
   BigInt, 
   BigDecimal, 
   Address, 
-  EthereumTransaction, 
-  EthereumBlock 
+  ethereum 
 } from '@graphprotocol/graph-ts'
 
 import {
@@ -15,7 +14,7 @@ export const BigIntOne =  BigInt.fromI32(1)
 export const BigDecimalZero = BigDecimal.fromString('0')
 export const BigDecimalOne = BigDecimal.fromString('1')
 
-export function createTransaction(tx: EthereumTransaction, block: EthereumBlock): Transaction {
+export function createTransaction(tx: ethereum.Transaction, block: ethereum.Block): Transaction {
   let txEntity = new Transaction(tx.hash.toHexString().toString())
   txEntity.txIndex = tx.index
   txEntity.from = tx.from
@@ -26,7 +25,7 @@ export function createTransaction(tx: EthereumTransaction, block: EthereumBlock)
   return txEntity
 }
 
-export function getCreateTransaction(tx: EthereumTransaction, block: EthereumBlock): Transaction {
+export function getCreateTransaction(tx: ethereum.Transaction, block: ethereum.Block): Transaction {
   let txEntity = Transaction.load(tx.hash.toHexString().toString())
   if (txEntity == null) {
     txEntity = createTransaction(tx, block)


### PR DESCRIPTION
Manifest:
-Bump mapping API from `0.0.3` to `0.0.5`

Package.json:
-Bump `graph-cli` version from `^0.16.0` to `^0.22.0`

util.ts:
-Change imports to reflect more recent graph-cli version naming scheme
(e.g.: `EthereumBlock` to `ethereum.Block`)